### PR TITLE
Replace log with logrus

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -6,7 +6,7 @@ package helm
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"os"
 	"strconv"

--- a/helm/provider_test.go
+++ b/helm/provider_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"os"

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"os"
 	"path"

--- a/helm/structure_kubeconfig.go
+++ b/helm/structure_kubeconfig.go
@@ -6,7 +6,7 @@ package helm
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"sync"

--- a/vendor/github.com/Azure/go-ansiterm/parser.go
+++ b/vendor/github.com/Azure/go-ansiterm/parser.go
@@ -2,7 +2,7 @@ package ansiterm
 
 import (
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/Azure/go-ansiterm/winterm/win_event_handler.go
+++ b/vendor/github.com/Azure/go-ansiterm/winterm/win_event_handler.go
@@ -4,7 +4,7 @@ package winterm
 
 import (
 	"bytes"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strconv"
 

--- a/vendor/github.com/emicklei/go-restful/v3/log/log.go
+++ b/vendor/github.com/emicklei/go-restful/v3/log/log.go
@@ -1,7 +1,7 @@
 package log
 
 import (
-	stdlog "log"
+	stdlog log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/go-gorp/gorp/v3/db.go
+++ b/vendor/github.com/go-gorp/gorp/v3/db.go
@@ -11,7 +11,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strconv"
 	"strings"

--- a/vendor/github.com/go-gorp/gorp/v3/nulltypes.go
+++ b/vendor/github.com/go-gorp/gorp/v3/nulltypes.go
@@ -6,7 +6,7 @@ package gorp
 
 import (
 	"database/sql/driver"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/github.com/go-openapi/swag/json.go
+++ b/vendor/github.com/go-openapi/swag/json.go
@@ -17,7 +17,7 @@ package swag
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 	"sync"

--- a/vendor/github.com/go-openapi/swag/loading.go
+++ b/vendor/github.com/go-openapi/swag/loading.go
@@ -17,7 +17,7 @@ package swag
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"path/filepath"

--- a/vendor/github.com/gogo/protobuf/proto/clone.go
+++ b/vendor/github.com/gogo/protobuf/proto/clone.go
@@ -36,7 +36,7 @@ package proto
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/github.com/gogo/protobuf/proto/equal.go
+++ b/vendor/github.com/gogo/protobuf/proto/equal.go
@@ -35,7 +35,7 @@ package proto
 
 import (
 	"bytes"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/github.com/gogo/protobuf/proto/lib.go
+++ b/vendor/github.com/gogo/protobuf/proto/lib.go
@@ -224,7 +224,7 @@ To create and play with a Test object:
 	package main
 
 	import (
-		"log"
+		log "github.com/sourcegraph-ce/logrus"
 
 		"github.com/gogo/protobuf/proto"
 		pb "./example.pb"
@@ -266,7 +266,7 @@ package proto
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/gogo/protobuf/proto/properties.go
+++ b/vendor/github.com/gogo/protobuf/proto/properties.go
@@ -42,7 +42,7 @@ package proto
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/gogo/protobuf/proto/text.go
+++ b/vendor/github.com/gogo/protobuf/proto/text.go
@@ -45,7 +45,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"reflect"
 	"sort"

--- a/vendor/github.com/google/gnostic/compiler/reader.go
+++ b/vendor/github.com/google/gnostic/compiler/reader.go
@@ -17,7 +17,7 @@ package compiler
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"path/filepath"

--- a/vendor/github.com/google/gnostic/extensions/extensions.go
+++ b/vendor/github.com/google/gnostic/extensions/extensions.go
@@ -16,7 +16,7 @@ package gnostic_extension_v1
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 
 	"github.com/golang/protobuf/proto"

--- a/vendor/github.com/google/gnostic/jsonschema/operations.go
+++ b/vendor/github.com/google/gnostic/jsonschema/operations.go
@@ -16,7 +16,7 @@ package jsonschema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 )
 

--- a/vendor/github.com/hashicorp/go-hclog/interceptlogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/interceptlogger.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 	"sync/atomic"
 )

--- a/vendor/github.com/hashicorp/go-hclog/intlogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/intlogger.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"reflect"
 	"runtime"

--- a/vendor/github.com/hashicorp/go-hclog/logger.go
+++ b/vendor/github.com/hashicorp/go-hclog/logger.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"time"

--- a/vendor/github.com/hashicorp/go-hclog/nulllogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/nulllogger.go
@@ -3,7 +3,7 @@ package hclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // NewNullLogger instantiates a Logger for which all calls

--- a/vendor/github.com/hashicorp/go-hclog/stdlog.go
+++ b/vendor/github.com/hashicorp/go-hclog/stdlog.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"bytes"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 )

--- a/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/mux_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/mux_broker.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/binary"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/rpc_server.go
+++ b/vendor/github.com/hashicorp/go-plugin/rpc_server.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/rpc"
 	"sync"

--- a/vendor/github.com/hashicorp/go-plugin/stream.go
+++ b/vendor/github.com/hashicorp/go-plugin/stream.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 func copyStream(name string, dst io.Writer, src io.Reader) {

--- a/vendor/github.com/hashicorp/hc-install/checkpoint/latest_version.go
+++ b/vendor/github.com/hashicorp/hc-install/checkpoint/latest_version.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"runtime"

--- a/vendor/github.com/hashicorp/hc-install/fs/any_version.go
+++ b/vendor/github.com/hashicorp/hc-install/fs/any_version.go
@@ -3,7 +3,7 @@ package fs
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"path/filepath"
 
 	"github.com/hashicorp/hc-install/errors"

--- a/vendor/github.com/hashicorp/hc-install/fs/exact_version.go
+++ b/vendor/github.com/hashicorp/hc-install/fs/exact_version.go
@@ -3,7 +3,7 @@ package fs
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"path/filepath"
 	"time"
 

--- a/vendor/github.com/hashicorp/hc-install/fs/fs.go
+++ b/vendor/github.com/hashicorp/hc-install/fs/fs.go
@@ -2,7 +2,7 @@ package fs
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/hc-install/fs/version.go
+++ b/vendor/github.com/hashicorp/hc-install/fs/version.go
@@ -3,7 +3,7 @@ package fs
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"path/filepath"
 	"time"
 

--- a/vendor/github.com/hashicorp/hc-install/installer.go
+++ b/vendor/github.com/hashicorp/hc-install/installer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hc-install/errors"

--- a/vendor/github.com/hashicorp/hc-install/internal/build/go_build.go
+++ b/vendor/github.com/hashicorp/hc-install/internal/build/go_build.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"os/exec"
 	"path/filepath"

--- a/vendor/github.com/hashicorp/hc-install/internal/releasesjson/checksum_downloader.go
+++ b/vendor/github.com/hashicorp/hc-install/internal/releasesjson/checksum_downloader.go
@@ -7,7 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"strings"

--- a/vendor/github.com/hashicorp/hc-install/internal/releasesjson/downloader.go
+++ b/vendor/github.com/hashicorp/hc-install/internal/releasesjson/downloader.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/github.com/hashicorp/hc-install/internal/releasesjson/releases.go
+++ b/vendor/github.com/hashicorp/hc-install/internal/releasesjson/releases.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"strings"

--- a/vendor/github.com/hashicorp/hc-install/releases/exact_version.go
+++ b/vendor/github.com/hashicorp/hc-install/releases/exact_version.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"time"

--- a/vendor/github.com/hashicorp/hc-install/releases/latest_version.go
+++ b/vendor/github.com/hashicorp/hc-install/releases/latest_version.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"sort"

--- a/vendor/github.com/hashicorp/hc-install/releases/releases.go
+++ b/vendor/github.com/hashicorp/hc-install/releases/releases.go
@@ -2,7 +2,7 @@ package releases
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/hc-install/src/src.go
+++ b/vendor/github.com/hashicorp/hc-install/src/src.go
@@ -2,7 +2,7 @@ package src
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	isrc "github.com/hashicorp/hc-install/internal/src"
 )

--- a/vendor/github.com/hashicorp/hcl/v2/doc.go
+++ b/vendor/github.com/hashicorp/hcl/v2/doc.go
@@ -9,7 +9,7 @@
 //     package main
 //
 //     import (
-//     	"log"
+//     	log "github.com/sourcegraph-ce/logrus"
 //     	"github.com/hashicorp/hcl/v2/hclsimple"
 //     )
 //

--- a/vendor/github.com/hashicorp/logutils/level.go
+++ b/vendor/github.com/hashicorp/logutils/level.go
@@ -51,7 +51,7 @@ func (f *LevelFilter) Check(line []byte) bool {
 
 func (f *LevelFilter) Write(p []byte) (n int, err error) {
 	// Note in general that io.Writer can receive any byte sequence
-	// to write, but the "log" package always guarantees that we only
+	// to write, but the log "github.com/sourcegraph-ce/logrus" package always guarantees that we only
 	// get a single line. We use that as a slight optimization within
 	// this method, assuming we're dealing with a single, complete line
 	// of log data.

--- a/vendor/github.com/hashicorp/terraform-exec/tfexec/terraform.go
+++ b/vendor/github.com/hashicorp/terraform-exec/tfexec/terraform.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"sync"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-docs/internal/provider/util.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-docs/internal/provider/util.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"os/exec"
 	"path/filepath"

--- a/vendor/github.com/hashicorp/terraform-plugin-go/internal/logging/provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-go/internal/logging/provider.go
@@ -1,7 +1,7 @@
 package logging
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	tfaddr "github.com/hashicorp/terraform-registry-address"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/logging.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/logging.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"syscall"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/transport.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/transport.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/http/httputil"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/state.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"regexp"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/field_reader_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/field_reader_config.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/provider.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"sort"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_data.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_data.go
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_timeout.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_timeout.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/mitchellh/copystructure"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/schema.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/schema.go
@@ -14,7 +14,7 @@ package schema
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"reflect"
 	"regexp"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/plugin/serve.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/plugin/serve.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/terraform/diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/terraform/diff.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"regexp"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/terraform/state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/terraform/state.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"reflect"
 	"sort"

--- a/vendor/github.com/hashicorp/yamux/mux.go
+++ b/vendor/github.com/hashicorp/yamux/mux.go
@@ -3,7 +3,7 @@ package yamux
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"time"
 )

--- a/vendor/github.com/hashicorp/yamux/session.go
+++ b/vendor/github.com/hashicorp/yamux/session.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"strings"

--- a/vendor/github.com/klauspost/compress/zstd/zstd.go
+++ b/vendor/github.com/klauspost/compress/zstd/zstd.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"math/bits"
 )

--- a/vendor/github.com/mitchellh/cli/help.go
+++ b/vendor/github.com/mitchellh/cli/help.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 )

--- a/vendor/github.com/mitchellh/go-testing-interface/testing.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing.go
@@ -2,7 +2,7 @@ package testing
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // T is the interface that mimics the standard library *testing.T.

--- a/vendor/github.com/moby/spdystream/utils.go
+++ b/vendor/github.com/moby/spdystream/utils.go
@@ -17,7 +17,7 @@
 package spdystream
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/modern-go/concurrent/log.go
+++ b/vendor/github.com/modern-go/concurrent/log.go
@@ -2,7 +2,7 @@ package concurrent
 
 import (
 	"os"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"io/ioutil"
 )
 

--- a/vendor/github.com/posener/complete/log.go
+++ b/vendor/github.com/posener/complete/log.go
@@ -2,7 +2,7 @@ package complete
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/prometheus/client_golang/prometheus/doc.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/doc.go
@@ -28,7 +28,7 @@
 //	package main
 //
 //	import (
-//		"log"
+//		log "github.com/sourcegraph-ce/logrus"
 //		"net/http"
 //
 //		"github.com/prometheus/client_golang/prometheus"

--- a/vendor/github.com/prometheus/procfs/doc.go
+++ b/vendor/github.com/prometheus/procfs/doc.go
@@ -20,7 +20,7 @@
 //
 //    import (
 //    	"fmt"
-//    	"log"
+//    	log "github.com/sourcegraph-ce/logrus"
 //
 //    	"github.com/prometheus/procfs"
 //    )

--- a/vendor/github.com/sirupsen/logrus/logrus.go
+++ b/vendor/github.com/sirupsen/logrus/logrus.go
@@ -2,7 +2,7 @@ package logrus
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 )
 

--- a/vendor/github.com/vmihailenco/msgpack/v4/types.go
+++ b/vendor/github.com/vmihailenco/msgpack/v4/types.go
@@ -3,7 +3,7 @@ package msgpack
 import (
 	"encoding"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sync"
 

--- a/vendor/github.com/xeipuuv/gojsonschema/internalLog.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/internalLog.go
@@ -27,7 +27,7 @@
 package gojsonschema
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 const internalLogEnabled = false

--- a/vendor/go.starlark.net/internal/compile/compile.go
+++ b/vendor/go.starlark.net/internal/compile/compile.go
@@ -29,7 +29,7 @@ package compile // import "go.starlark.net/internal/compile"
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strconv"

--- a/vendor/go.starlark.net/resolve/resolve.go
+++ b/vendor/go.starlark.net/resolve/resolve.go
@@ -83,7 +83,7 @@ package resolve // import "go.starlark.net/resolve"
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 

--- a/vendor/go.starlark.net/starlark/eval.go
+++ b/vendor/go.starlark.net/starlark/eval.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"math/big"
 	"sort"

--- a/vendor/go.starlark.net/starlark/profile.go
+++ b/vendor/go.starlark.net/starlark/profile.go
@@ -65,7 +65,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sync/atomic"
 	"time"

--- a/vendor/go.starlark.net/starlark/unpack.go
+++ b/vendor/go.starlark.net/starlark/unpack.go
@@ -5,7 +5,7 @@ package starlark
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/go.starlark.net/syntax/parse.go
+++ b/vendor/go.starlark.net/syntax/parse.go
@@ -11,7 +11,7 @@ package syntax
 // package.  Verify that error positions are correct using the
 // chunkedfile mechanism.
 
-import "log"
+import log "github.com/sourcegraph-ce/logrus"
 
 // Enable this flag to print the token stream and log.Fatal on the first error.
 const debug = false

--- a/vendor/go.starlark.net/syntax/scan.go
+++ b/vendor/go.starlark.net/syntax/scan.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math/big"
 	"os"
 	"strconv"

--- a/vendor/golang.org/x/crypto/ssh/channel.go
+++ b/vendor/golang.org/x/crypto/ssh/channel.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 )
 

--- a/vendor/golang.org/x/crypto/ssh/handshake.go
+++ b/vendor/golang.org/x/crypto/ssh/handshake.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 )

--- a/vendor/golang.org/x/crypto/ssh/mux.go
+++ b/vendor/golang.org/x/crypto/ssh/mux.go
@@ -8,7 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 	"sync/atomic"
 )

--- a/vendor/golang.org/x/crypto/ssh/transport.go
+++ b/vendor/golang.org/x/crypto/ssh/transport.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // debugTransport if set, will print packet types as they go over the

--- a/vendor/golang.org/x/net/http2/frame.go
+++ b/vendor/golang.org/x/net/http2/frame.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"sync"
 

--- a/vendor/golang.org/x/net/http2/server.go
+++ b/vendor/golang.org/x/net/http2/server.go
@@ -33,7 +33,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"net/http"

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	mathrand "math/rand"
 	"net"

--- a/vendor/golang.org/x/net/http2/write.go
+++ b/vendor/golang.org/x/net/http2/write.go
@@ -7,7 +7,7 @@ package http2
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 

--- a/vendor/golang.org/x/net/internal/timeseries/timeseries.go
+++ b/vendor/golang.org/x/net/internal/timeseries/timeseries.go
@@ -7,7 +7,7 @@ package timeseries // import "golang.org/x/net/internal/timeseries"
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/golang.org/x/net/trace/events.go
+++ b/vendor/golang.org/x/net/trace/events.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"runtime"
 	"sort"

--- a/vendor/golang.org/x/net/trace/histogram.go
+++ b/vendor/golang.org/x/net/trace/histogram.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"sync"
 

--- a/vendor/golang.org/x/net/trace/trace.go
+++ b/vendor/golang.org/x/net/trace/trace.go
@@ -68,7 +68,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/golang.org/x/oauth2/transport.go
+++ b/vendor/golang.org/x/oauth2/transport.go
@@ -6,7 +6,7 @@ package oauth2
 
 import (
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"sync"
 )

--- a/vendor/golang.org/x/text/unicode/bidi/core.go
+++ b/vendor/golang.org/x/text/unicode/bidi/core.go
@@ -6,7 +6,7 @@ package bidi
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // This implementation is a port based on the reference implementation found at:

--- a/vendor/google.golang.org/appengine/internal/api.go
+++ b/vendor/google.golang.org/appengine/internal/api.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/google.golang.org/appengine/internal/identity_vm.go
+++ b/vendor/google.golang.org/appengine/internal/identity_vm.go
@@ -7,7 +7,7 @@
 package internal
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vendor/google.golang.org/appengine/internal/main_vm.go
+++ b/vendor/google.golang.org/appengine/internal/main_vm.go
@@ -8,7 +8,7 @@ package internal
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/google.golang.org/appengine/internal/net.go
+++ b/vendor/google.golang.org/appengine/internal/net.go
@@ -8,7 +8,7 @@ package internal
 // It is only used for API calls.
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"runtime"
 	"sync"

--- a/vendor/google.golang.org/grpc/grpclog/loggerv2.go
+++ b/vendor/google.golang.org/grpc/grpclog/loggerv2.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strconv"
 	"strings"

--- a/vendor/helm.sh/helm/v3/internal/ignore/rules.go
+++ b/vendor/helm.sh/helm/v3/internal/ignore/rules.go
@@ -20,7 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/helm.sh/helm/v3/internal/sympath/walk.go
+++ b/vendor/helm.sh/helm/v3/internal/sympath/walk.go
@@ -21,7 +21,7 @@ limitations under the License.
 package sympath
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"sort"

--- a/vendor/helm.sh/helm/v3/pkg/chart/loader/load.go
+++ b/vendor/helm.sh/helm/v3/pkg/chart/loader/load.go
@@ -18,7 +18,7 @@ package loader
 
 import (
 	"bytes"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/helm.sh/helm/v3/pkg/chartutil/coalesce.go
+++ b/vendor/helm.sh/helm/v3/pkg/chartutil/coalesce.go
@@ -18,7 +18,7 @@ package chartutil
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/mitchellh/copystructure"
 	"github.com/pkg/errors"

--- a/vendor/helm.sh/helm/v3/pkg/chartutil/dependencies.go
+++ b/vendor/helm.sh/helm/v3/pkg/chartutil/dependencies.go
@@ -16,7 +16,7 @@ limitations under the License.
 package chartutil
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"helm.sh/helm/v3/pkg/chart"

--- a/vendor/helm.sh/helm/v3/pkg/downloader/manager.go
+++ b/vendor/helm.sh/helm/v3/pkg/downloader/manager.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"os"
 	"path"

--- a/vendor/helm.sh/helm/v3/pkg/engine/engine.go
+++ b/vendor/helm.sh/helm/v3/pkg/engine/engine.go
@@ -18,7 +18,7 @@ package engine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"path"
 	"path/filepath"
 	"regexp"

--- a/vendor/helm.sh/helm/v3/pkg/engine/lookup_func.go
+++ b/vendor/helm.sh/helm/v3/pkg/engine/lookup_func.go
@@ -18,7 +18,7 @@ package engine
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/pkg/errors"

--- a/vendor/helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go
+++ b/vendor/helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go
@@ -17,7 +17,7 @@ limitations under the License.
 package releaseutil
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"path"
 	"sort"
 	"strconv"

--- a/vendor/helm.sh/helm/v3/pkg/repo/chartrepo.go
+++ b/vendor/helm.sh/helm/v3/pkg/repo/chartrepo.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"os"
 	"path/filepath"

--- a/vendor/helm.sh/helm/v3/pkg/repo/index.go
+++ b/vendor/helm.sh/helm/v3/pkg/repo/index.go
@@ -19,7 +19,7 @@ package repo
 import (
 	"bytes"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path"
 	"path/filepath"

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/pod_expansion.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/pod_expansion.go
@@ -67,7 +67,7 @@ func (c *pods) EvictV1(ctx context.Context, eviction *policyv1.Eviction) error {
 
 // Get constructs a request for getting the logs for a pod
 func (c *pods) GetLogs(name string, opts *v1.PodLogOptions) *restclient.Request {
-	return c.client.Get().Namespace(c.ns).Name(name).Resource("pods").SubResource("log").VersionedParams(opts, scheme.ParameterCodec)
+	return c.client.Get().Namespace(c.ns).Name(name).Resource("pods").SubResource(log "github.com/sourcegraph-ce/logrus").VersionedParams(opts, scheme.ParameterCodec)
 }
 
 // ProxyGet returns a response of the pod by calling it through the proxy.

--- a/vendor/k8s.io/klog/klog.go
+++ b/vendor/k8s.io/klog/klog.go
@@ -77,7 +77,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	stdLog "log"
+	stdLog log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"os"
 	"path/filepath"
@@ -1032,7 +1032,7 @@ func (l *loggingT) flushAll() {
 	}
 }
 
-// CopyStandardLogTo arranges for messages written to the Go "log" package's
+// CopyStandardLogTo arranges for messages written to the Go log "github.com/sourcegraph-ce/logrus" package's
 // default logs to also appear in the Google logs for the named and lower
 // severities.  Subsequent changes to the standard log's default output location
 // or format may break this behavior.

--- a/vendor/k8s.io/klog/v2/klog.go
+++ b/vendor/k8s.io/klog/v2/klog.go
@@ -80,7 +80,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	stdLog "log"
+	stdLog log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"os"
 	"path/filepath"
@@ -1204,7 +1204,7 @@ func (l *loggingT) flushAll() {
 	}
 }
 
-// CopyStandardLogTo arranges for messages written to the Go "log" package's
+// CopyStandardLogTo arranges for messages written to the Go log "github.com/sourcegraph-ce/logrus" package's
 // default logs to also appear in the Google logs for the named and lower
 // severities.  Subsequent changes to the standard log's default output location
 // or format may break this behavior.

--- a/vendor/sigs.k8s.io/kustomize/api/filters/refvar/expand.go
+++ b/vendor/sigs.k8s.io/kustomize/api/filters/refvar/expand.go
@@ -5,7 +5,7 @@ package refvar
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 )
 

--- a/vendor/sigs.k8s.io/kustomize/api/internal/accumulator/namereferencetransformer.go
+++ b/vendor/sigs.k8s.io/kustomize/api/internal/accumulator/namereferencetransformer.go
@@ -5,7 +5,7 @@ package accumulator
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"sigs.k8s.io/kustomize/api/filters/nameref"
 	"sigs.k8s.io/kustomize/api/internal/plugins/builtinconfig"

--- a/vendor/sigs.k8s.io/kustomize/api/internal/accumulator/resaccumulator.go
+++ b/vendor/sigs.k8s.io/kustomize/api/internal/accumulator/resaccumulator.go
@@ -5,7 +5,7 @@ package accumulator
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"sigs.k8s.io/kustomize/api/internal/plugins/builtinconfig"

--- a/vendor/sigs.k8s.io/kustomize/api/internal/plugins/builtinconfig/transformerconfig.go
+++ b/vendor/sigs.k8s.io/kustomize/api/internal/plugins/builtinconfig/transformerconfig.go
@@ -4,7 +4,7 @@
 package builtinconfig
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 
 	"sigs.k8s.io/kustomize/api/ifc"

--- a/vendor/sigs.k8s.io/kustomize/api/internal/plugins/loader/loader.go
+++ b/vendor/sigs.k8s.io/kustomize/api/internal/plugins/loader/loader.go
@@ -5,7 +5,7 @@ package loader
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"plugin"

--- a/vendor/sigs.k8s.io/kustomize/api/loader/fileloader.go
+++ b/vendor/sigs.k8s.io/kustomize/api/loader/fileloader.go
@@ -6,7 +6,7 @@ package loader
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"path/filepath"

--- a/vendor/sigs.k8s.io/kustomize/api/resource/factory.go
+++ b/vendor/sigs.k8s.io/kustomize/api/resource/factory.go
@@ -6,7 +6,7 @@ package resource
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"sigs.k8s.io/kustomize/api/ifc"

--- a/vendor/sigs.k8s.io/kustomize/api/resource/resource.go
+++ b/vendor/sigs.k8s.io/kustomize/api/resource/resource.go
@@ -5,7 +5,7 @@ package resource
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"sigs.k8s.io/kustomize/api/filters/patchstrategicmerge"

--- a/vendor/sigs.k8s.io/kustomize/kyaml/filesys/fsnode.go
+++ b/vendor/sigs.k8s.io/kustomize/kyaml/filesys/fsnode.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"regexp"

--- a/vendor/sigs.k8s.io/kustomize/kyaml/filesys/fsondisk.go
+++ b/vendor/sigs.k8s.io/kustomize/kyaml/filesys/fsondisk.go
@@ -6,7 +6,7 @@ package filesys
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 

--- a/vendor/sigs.k8s.io/kustomize/kyaml/yaml/internal/k8sgen/pkg/labels/selector.go
+++ b/vendor/sigs.k8s.io/kustomize/kyaml/yaml/internal/k8sgen/pkg/labels/selector.go
@@ -26,7 +26,7 @@ import (
 	"strconv"
 	"strings"
 
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sigs.k8s.io/kustomize/kyaml/yaml/internal/k8sgen/pkg/selection"
 	"sigs.k8s.io/kustomize/kyaml/yaml/internal/k8sgen/pkg/util/sets"
 	"sigs.k8s.io/kustomize/kyaml/yaml/internal/k8sgen/pkg/util/validation"

--- a/vendor/sigs.k8s.io/kustomize/kyaml/yaml/rnode.go
+++ b/vendor/sigs.k8s.io/kustomize/kyaml/yaml/rnode.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strconv"
 	"strings"


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-helm', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
.changelog
.release
scripts
.github
vendor
website
tools
.git
_about
helm
workflows
ISSUE_TEMPLATE
sigs.k8s.io
go.starlark.net
helm.sh
gopkg.in
oras.land
google.golang.org
golang.org
k8s.io
github.com
kustomize
json
yaml
structured-merge-diff
kyaml
api
openapi
utils
ext
runfn
internal
resid
order
filesys
yaml
kio
sets
fn
comments
fieldmeta
errors
sliceutil
kubernetesapi
kustomizationapi
v1212
forked
github.com
qri-io
go-yaml
starlib
util
yaml
merge3
walk
schema
merge2
internal
k8sgen
pkg
selection
labels
util
sets
validation
errors
field
kioutil
filters
runtime
container
starlark
runtimeutil
exec
provider
loader
image
hasher
internal
filters
krusty
kv
ifc
resmap
provenance
resource
konfig
types
utils
kusterr
accumulator
generators
target
plugins
validate
git
builtins
utils
loader
builtinconfig
builtinhelpers
execplugin
fnplugin
valueadd
namespace
replacement
prefix
filtersutil
annotations
labels
iampolicygenerator
suffix
nameref
imagetag
refvar
patchstrategicmerge
fsslice
replicacount
fieldspec
patchjson6902
builtinpluginconsts
internal
golang
encoding
json
v4
value
schema
fieldpath
typed
starlarkstruct
resolve
internal
syntax
starlark
compile
spell
helm
v3
internal
pkg
third_party
fileutil
ignore
sympath
urlutil
resolver
tlsutil
version
dep
k8s.io
fs
kubernetes
deployment
util
kube
storage
cli
lint
postrender
release
helmpath
chart
repo
plugin
getter
pusher
releaseutil
provenance
engine
registry
downloader
chartutil
strvals
uploader
action
time
fake
driver
support
rules
xdg
loader
inf.v0
yaml.v2
yaml.v3
oras-go
pkg
target
content
context
artifact
registry
auth
oras
remote
internal
auth
errutil
syncutil
docker
protobuf
grpc
genproto
appengine
proto
reflect
internal
types
runtime
encoding
protodesc
protoreflect
protoregistry
descopts
genid
set
flags
filetype
detrand
order
impl
filedesc
descfmt
pragma
encoding
strs
errors
version
messageset
json
tag
defval
text
known
descriptorpb
emptypb
anypb
timestamppb
durationpb
protoiface
protoimpl
protojson
prototext
protowire
keepalive
grpclog
health
stats
binarylog
codes
reflection
internal
backoff
connectivity
attributes
status
credentials
serviceconfig
resolver
channelz
tap
peer
balancer
encoding
metadata
grpc_health_v1
grpc_binarylog_v1
grpc_reflection_v1alpha
grpcrand
syscall
grpclog
transport
pretty
grpcutil
envconfig
binarylog
buffer
backoff
grpcsync
status
credentials
serviceconfig
resolver
channelz
balancerload
balancer
metadata
networktype
unix
dns
passthrough
gracefulswitch
insecure
grpclb
base
roundrobin
state
proto
googleapis
rpc
status
datastore
urlfetch
internal
internal
cloudkey
cloudpb
app_identity
datastore
urlfetch
base
log
remote_api
modules
x
crypto
mod
net
sys
sync
term
oauth2
time
text
sha3
cast5
ssh
internal
openpgp
scrypt
curve25519
pbkdf2
blowfish
bcrypt
chacha20
ed25519
internal
bcrypt_pbkdf
alias
poly1305
s2k
clearsign
armor
packet
elgamal
errors
internal
field
internal
modfile
module
semver
lazyregexp
http
idna
internal
context
proxy
http2
trace
httpguts
socks
timeseries
ctxhttp
hpack
unix
windows
plan9
internal
cpu
execabs
unsafeheader
semaphore
errgroup
internal
rate
unicode
internal
secure
cases
transform
language
runes
encoding
bidi
norm
tag
language
utf8internal
compact
bidirule
unicode
internal
identifier
klog
utils
apiserver
apimachinery
apiextensions-apiserver
component-base
kube-openapi
cli-runtime
client-go
api
kubectl
v2
internal
severity
dbg
buffer
serialize
clock
net
integer
buffer
internal
strings
clock
pointer
trace
exec
third_party
forked
golang
net
slices
testing
pkg
endpoints
deprecation
third_party
pkg
forked
golang
json
netutil
reflect
fields
watch
selection
labels
apis
types
runtime
conversion
util
api
version
meta
internalversion
v1beta1
v1
unstructured
validation
unstructuredscheme
serializer
schema
protobuf
versioning
json
streaming
recognizer
queryparams
managedfields
net
httpstream
wait
diff
intstr
cache
json
naming
remotecommand
duration
yaml
sets
framer
mergepatch
runtime
strategicpatch
validation
errors
spdy
field
meta
resource
equality
validation
errors
path
pkg
apis
apiextensions
v1beta1
v1
version
pkg
spec3
schemamutation
internal
openapiconv
schemaconv
common
builder3
util
handler3
validation
third_party
handler
go-json-experiment
json
util
proto
validation
spec
pkg
printers
genericclioptions
resource
openapi
third_party
transport
discovery
plugin
kubernetes
rest
dynamic
tools
pkg
scale
util
restmapper
applyconfigurations
cached
forked
golang
template
spdy
cached
memory
disk
pkg
client
auth
azure
oidc
exec
gcp
typed
scheme
networking
storage
certificates
extensions
scheduling
discovery
autoscaling
node
coordination
admissionregistration
policy
authorization
apps
batch
apiserverinternal
resource
authentication
events
core
flowcontrol
rbac
v1beta1
v1
v1alpha1
v1beta1
v1
v1alpha1
v1beta1
v1
v1beta1
v1beta1
v1
v1alpha1
v1beta1
v1
v2beta2
v1
v2
v2beta1
v1beta1
v1
v1alpha1
v1beta1
v1
v1beta1
v1
v1alpha1
v1beta1
v1
v1beta1
v1
v1beta1
v1
v1beta2
v1beta1
v1
v1alpha1
v1alpha1
v1beta1
v1
v1alpha1
v1beta1
v1
v1
v1beta1
v1beta2
v1alpha1
v1beta3
v1beta1
v1
v1alpha1
watch
watch
cache
clientcmd
metrics
remotecommand
reference
auth
pager
api
v1
latest
apis
version
clientauthentication
v1beta1
v1
install
scheme
appsv1beta1
appsint
autoscalingv1
extensionsint
extensionsv1beta1
appsv1beta2
jsonpath
cert
workqueue
keyutil
homedir
connrotation
flowcontrol
exec
networking
storage
certificates
extensions
scheduling
discovery
autoscaling
internal
node
coordination
meta
admissionregistration
policy
apps
batch
apiserverinternal
resource
events
core
flowcontrol
rbac
v1beta1
v1
v1alpha1
v1beta1
v1
v1alpha1
v1beta1
v1
v1beta1
v1beta1
v1
v1alpha1
v1beta1
v1
v2beta2
v1
v2
v2beta1
v1beta1
v1
v1alpha1
v1beta1
v1
v1
v1beta1
v1
v1alpha1
v1beta1
v1
v1beta1
v1
v1beta2
v1beta1
v1
v1alpha1
v1alpha1
v1beta1
v1
v1
v1beta1
v1beta2
v1alpha1
v1beta3
v1beta1
v1
v1alpha1
networking
storage
certificates
extensions
scheduling
discovery
admission
autoscaling
node
coordination
admissionregistration
policy
authorization
apps
batch
apiserverinternal
resource
authentication
events
imagepolicy
core
flowcontrol
apidiscovery
rbac
v1beta1
v1
v1alpha1
v1beta1
v1
v1alpha1
v1beta1
v1
v1beta1
v1beta1
v1
v1alpha1
v1beta1
v1
v1beta1
v1
v2beta2
v1
v2
v2beta1
v1beta1
v1
v1alpha1
v1beta1
v1
v1beta1
v1
v1alpha1
v1beta1
v1
v1beta1
v1
v1beta1
v1
v1beta2
v1beta1
v1
v1alpha1
v1alpha1
v1beta1
v1
v1alpha1
v1beta1
v1
v1alpha1
v1
v1beta1
v1beta2
v1alpha1
v1beta3
v2beta1
v1beta1
v1
v1alpha1
pkg
cmd
scheme
util
validation
util
openapi
templates
i18n
interrupt
term
validation
translations
test
kubectl
default
en_US
LC_MESSAGES
LC_MESSAGES
zh_CN
de_DE
zh_TW
default
ko_KR
it_IT
fr_FR
ja_JP
pt_BR
en_US
LC_MESSAGES
LC_MESSAGES
LC_MESSAGES
LC_MESSAGES
LC_MESSAGES
LC_MESSAGES
LC_MESSAGES
LC_MESSAGES
LC_MESSAGES
LC_MESSAGES
MakeNowJust
lann
gogo
BurntSushi
stretchr
liggitt
huandu
jmoiron
modern-go
gosuri
docker
opencontainers
go-openapi
fatih
asaskevich
munnerz
mailru
russross
exponent-io
go-gorp
zclconf
Azure
josharian
moby
apparentlymart
golang
cyphar
shopspring
oklog
peterbourgon
go-logr
lib
gregjones
Masterminds
google
xeipuuv
json-iterator
go-errors
rubenv
sirupsen
hashicorp
inconshreveable
posener
spf13
mitchellh
imdario
matttproud
chai2010
gobwas
pkg
gorilla
cespare
evanphx
davecgh
emicklei
prometheus
xlab
containerd
pmezard
vmihailenco
beorn7
klauspost
monochromegane
mattn
armon
morikuni
bgentry
agext
heredoc
builder
ps
protobuf
proto
sortkeys
toml
internal
testify
assert
tabwriter
xstrings
sqlx
reflectx
reflect2
concurrent
uitable
util
strutil
wordwrap
cli
go-units
docker-credential-helpers
docker
go-metrics
distribution
go-connections
cli
config
credentials
configfile
types
credentials
client
rootless
errdefs
registry
pkg
api
stringid
ioutils
homedir
longpath
jsonmessage
types
network
swarm
filters
mount
strslice
blkiodev
container
registry
versions
runtime
digestset
metrics
reference
registry
storage
api
client
cache
memory
errcode
v2
transport
auth
challenge
nat
tlsconfig
image-spec
go-digest
specs-go
v1
jsonreference
swag
jsonpointer
internal
color
govalidator
goautoneg
easyjson
jwriter
buffer
jlexer
blackfriday
v2
jsonpath
gorp
v3
go-cty
cty
set
json
ctystrings
function
convert
gocty
stdlib
go-ansiterm
winterm
intern
spdystream
term
locker
spdy
windows
go-textseg
v13
textseg
protobuf
proto
ptypes
jsonpb
any
empty
duration
timestamp
filepath-securejoin
decimal
run
diskv
logr
pq
oid
scram
httpcache
sprig
goutils
squirrel
semver
v3
v3
gofuzz
uuid
shlex
btree
gnostic
go-cmp
bytesource
jsonschema
extensions
compiler
openapiv2
openapiv3
cmp
internal
diff
flags
value
function
gojsonpointer
gojsonreference
gojsonschema
go
errors
sql-migrate
sqlparse
test-migrations
logrus
go-plugin
terraform-plugin-log
yamux
errwrap
terraform-plugin-go
go-checkpoint
terraform-exec
go-uuid
terraform-plugin-sdk
go-version
go-multierror
terraform-registry-address
go-cleanhttp
terraform-json
go-cty
hcl
hc-install
terraform-plugin-docs
terraform-svchost
logutils
go-hclog
internal
plugin
tfsdklog
tflog
internal
hclogutils
logging
fieldutils
tfprotov5
tftypes
internal
tfprotov6
tf5server
internal
toproto
fromproto
diag
tfplugin5
tf5serverlogging
logging
internal
tf6server
toproto
tf6serverlogging
fromproto
tfplugin6
diag
internal
tfexec
version
v2
plugin
internal
diag
meta
terraform
helper
tfdiags
configs
plugin
plugintest
addrs
helper
logging
plans
hcl2shim
configschema
convert
hashcode
objchange
structure
schema
resource
logging
acctest
validation
cty
set
json
msgpack
convert
gocty
v2
ext
hclsyntax
customdecode
src
checkpoint
releases
internal
fs
product
errors
version
httpclient
src
pubkey
build
releasesjson
validators
cmd
internal
schemamd
tfplugindocs
provider
cmd
mdplain
tmplfuncs
mousetrap
complete
cmd
install
cast
pflag
cobra
go-homedir
cli
reflectwalk
go-testing-interface
copystructure
mapstructure
go-wordwrap
mergo
golang_protobuf_extensions
pbutil
gettext-go
plural
mo
po
glob
compiler
syntax
match
util
lexer
ast
strings
runes
errors
mux
xxhash
v2
json-patch
go-spew
spew
go-restful
v3
log
procfs
client_golang
common
client_model
internal
fs
util
prometheus
internal
promhttp
expfmt
internal
model
bitbucket.org
ww
goautoneg
go
treeprint
containerd
errdefs
archive
images
content
reference
filters
labels
platforms
log
remotes
version
compression
local
docker
errors
schema1
auth
go-difflib
difflib
msgpack
tagparser
v4
codes
codes
internal
parser
perks
quantile
compress
internal
huff0
fse
zstd
snapref
internal
xxhash
go-gitignore
go-runewidth
go-colorable
go-isatty
go-radix
aec
speakeasy
levenshtein
docs
r
guides
d
objects
info
branches
logs
refs
hooks
97
1b
31
08
94
8d
65
20
99
9f
24
4e
eb
6e
18
b6
e2
78
e6
66
b0
49
fe
01
bd
57
89
5a
c5
1e
e4
f5
d0
1c
44
95
72
dc
12
b7
ee
11
c8
22
1f
53
7a
47
5c
7c
07
fa
59
87
81
9e
75
52
8e
d6
96
ba
e3
29
02
f2
ac
3f
71
4a
ec
10
0e
e7
69
42
a9
9c
a3
6c
db
ea
ff
bf
dd
76
43
3e
34
60
1d
c9
4c
05
ca
26
06
a4
21
d2
85
19
fd
82
9b
a0
c2
f3
fb
b8
b4
cb
0b
c1
a6
0f
74
93
61
5b
51
cf
d1
c7
de
2a
f6
e9
pack
f7
ef
9a
8b
e8
da
d7
b3
ce
79
3a
b5
f1
ae
e0
be
28
a2
info
f8
80
e5
ed
a7
3c
9d
1a
15
a5
56
7d
c6
2b
fc
ad
09
2e
d4
4b
50
98
73
6d
27
f0
3b
70
7e
bc
7f
46
88
0c
c0
af
d5
a8
5e
35
16
b1
40
67
aa
ab
8c
3d
41
e1
b9
6b
23
84
00
37
83
4f
d3
54
0d
33
2f
8f
d9
39
36
55
63
17
77
c4
92
68
f9
c3
04
38
2c
8a
64
b2
7b
48
32
cd
91
6a
14
5d
bb
2d
cc
5f
58
45
f4
03
a1
25
6f
86
62
df
4d
0a
13
30
90
d8
refs
heads
tags
heads
test-infra
testdata
gke
manifest_json
charts
oci_registry
dependency-foo
crds-chart
kube-version
umbrella-chart
broken-chart
dependency-bar
test-chart-v2
test-chart
failed-deploy
templates
tests
templates
crds
tests
templates
templates
tests
templates
templates
tests
templates
tests
templates
tests
templates

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)